### PR TITLE
Remove direct dependency of states/node on routing table state

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -982,6 +982,9 @@ impl Chain {
             .map(|(event, _)| event)
     }
 
+    // Set of methods ported over from routing_table mostly as-is. The idea is to refactor and
+    // restructure them after they've all been ported over.
+
     /// Convert from collection of SectionInfo to Sections type. All neighbouring sections and our
     /// own.
     fn all_sections(&self) -> Sections<XorName> {
@@ -992,6 +995,313 @@ impl Chain {
             .collect::<BTreeMap<_,_>>()
     }
 
+    /// Finds the `count` names closest to `name` in the whole routing table.
+    fn closest_known_names(&self, name: &T, count: usize) -> Vec<&T> {
+        self.all_sections_iter()
+            .sorted_by(|&(pfx0, _), &(pfx1, _)| pfx0.cmp_distance(&pfx1, name))
+            .into_iter()
+            .flat_map(|(_, (_, section))| {
+                section
+                    .iter()
+                    .sorted_by(|name0, name1| name.cmp_distance(name0, name1))
+            })
+            .take(count)
+            .collect_vec()
+    }
+
+    /// Returns whether the table contains the given `name`.
+    pub fn has(&self, name: &T) -> bool {
+        self.get_section(name)
+            .map_or(false, |section| section.contains(name))
+    }
+
+    /// Returns the prefix of the section in which `name` belongs, or `None` if there is no such
+    /// section in the routing table.
+    pub fn find_section_prefix(&self, name: &T) -> Option<Prefix<T>> {
+        if self.our_prefix.matches(name) {
+            return Some(self.our_prefix);
+        }
+        self.sections
+            .keys()
+            .find(|&prefix| prefix.matches(name))
+            .cloned()
+    }
+
+    /// Returns the section matching the given `name`, if present.
+    /// Includes our own name in the case that our prefix matches `name`.
+    pub fn get_section(&self, name: &T) -> Option<&BTreeSet<T>> {
+        if self.our_prefix.matches(name) {
+            return Some(&self.our_section);
+        }
+        if let Some(prefix) = self.find_section_prefix(name) {
+            return self.sections.get(&prefix).map(|&(_, ref section)| section);
+        }
+        None
+    }
+
+    /// If our section is the closest one to `name`, returns all names in our section *including
+    /// ours*, otherwise returns `None`.
+    pub fn close_names(&self, name: &T) -> Option<BTreeSet<T>> {
+        if self.our_prefix.matches(name) {
+            Some(self.our_section().clone())
+        } else {
+            None
+        }
+    }
+
+    /// If our section is the closest one to `name`, returns all names in our section *excluding
+    /// ours*, otherwise returns `None`.
+    pub fn other_close_names(&self, name: &T) -> Option<BTreeSet<T>> {
+        if self.our_prefix.matches(name) {
+            let mut section = self.our_section.clone();
+            let _ = section.remove(&self.our_name);
+            Some(section)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the `count` closest entries to `name` in the routing table, including our own name,
+    /// sorted by ascending distance to `name`. If we are not close, returns `None`.
+    pub fn closest_names(&self, name: &T, count: usize) -> Option<Vec<&T>> {
+        let result = self.closest_known_names(name, count);
+        if result.contains(&&self.our_name) {
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the `count-1` closest entries to `name` in the routing table, excluding
+    /// our own name, sorted by ascending distance to `name` -  or `None`, if our name
+    /// isn't among `count` names closest to `name`.
+    pub fn other_closest_names(&self, name: &T, count: usize) -> Option<Vec<&T>> {
+        self.closest_names(name, count).map(|mut result| {
+            result.retain(|name| *name != &self.our_name);
+            result
+        })
+    }
+
+    /// Returns the prefix of the closest non-empty section to `name`, regardless of whether `name`
+    /// belongs in that section or not, and the section itself.
+    fn closest_section(&self, name: &T) -> (&Prefix<T>, &BTreeSet<T>) {
+        let mut result = (&self.our_prefix, &self.our_section);
+        for (prefix, &(_, ref section)) in &self.sections {
+            if !section.is_empty() && result.0.cmp_distance(prefix, name) == Ordering::Greater {
+                result = (prefix, section)
+            }
+        }
+        result
+    }
+
+    /// Gets the `route`-th name from a collection of names
+    fn get_routeth_name<'a, U: IntoIterator<Item = &'a T>>(
+        names: U,
+        dst_name: &T,
+        route: usize,
+    ) -> &'a T {
+        let sorted_names = names
+            .into_iter()
+            .sorted_by(|&lhs, &rhs| dst_name.cmp_distance(lhs, rhs));
+        sorted_names[route % sorted_names.len()]
+    }
+
+    /// Returns the `route`-th node in the given section, sorted by distance to `target`
+    fn get_routeth_node(
+        &self,
+        section: &BTreeSet<T>,
+        target: T,
+        exclude: Option<T>,
+        route: usize,
+    ) -> Result<T, Error> {
+        let names = if let Some(exclude) = exclude {
+            section.iter().filter(|&x| *x != exclude).collect_vec()
+        } else {
+            section.iter().collect_vec()
+        };
+
+        if names.is_empty() {
+            return Err(Error::CannotRoute);
+        }
+
+        Ok(*RoutingTable::get_routeth_name(names, &target, route))
+    }
+
+    /// Returns a collection of nodes to which a message for the given `Authority` should be sent
+    /// onwards. In all non-error cases below, the returned collection will have the members of
+    /// `exclude` removed, possibly resulting in an empty set being returned.
+    ///
+    /// * If the destination is an `Authority::Section`:
+    ///     - if our section is the closest on the network (i.e. our section's prefix is a prefix of
+    ///       the destination), returns all other members of our section; otherwise
+    ///     - returns the `route`-th closest member of the RT to the target
+    ///
+    /// * If the destination is an `Authority::PrefixSection`:
+    ///     - if the prefix is compatible with our prefix and is fully-covered by prefixes in our
+    ///       RT, returns all members in these prefixes except ourself; otherwise
+    ///     - if the prefix is compatible with our prefix and is *not* fully-covered by prefixes in
+    ///       our RT, returns `Err(Error::CannotRoute)`; otherwise
+    ///     - returns the `route`-th closest member of the RT to the lower bound of the target
+    ///       prefix
+    ///
+    /// * If the destination is a group (`ClientManager`, `NaeManager` or `NodeManager`):
+    ///     - if our section is the closest on the network (i.e. our section's prefix is a prefix of
+    ///       the destination), returns all other members of our section; otherwise
+    ///     - returns the `route`-th closest member of the RT to the target
+    ///
+    /// * If the destination is an individual node (`ManagedNode` or `Client`):
+    ///     - if our name *is* the destination, returns an empty set; otherwise
+    ///     - if the destination name is an entry in the routing table, returns it; otherwise
+    ///     - returns the `route`-th closest member of the RT to the target
+    pub fn targets(
+        &self,
+        dst: &Authority<T>,
+        exclude: T,
+        route: usize,
+    ) -> Result<BTreeSet<T>, Error> {
+        let candidates = |target_name: &T| {
+            self.closest_known_names(target_name, self.min_section_size)
+                .into_iter()
+                .filter(|name| **name != self.our_name)
+                .cloned()
+                .collect::<BTreeSet<T>>()
+        };
+
+        let closest_section = match *dst {
+            Authority::ManagedNode(ref target_name)
+            | Authority::Client {
+                proxy_node_name: ref target_name,
+                ..
+            } => {
+                if *target_name == self.our_name {
+                    return Ok(BTreeSet::new());
+                }
+                if self.has(target_name) {
+                    return Ok(iter::once(*target_name).collect());
+                }
+                candidates(target_name)
+            }
+            Authority::ClientManager(ref target_name)
+            | Authority::NaeManager(ref target_name)
+            | Authority::NodeManager(ref target_name) => {
+                if let Some(group) = self.other_closest_names(target_name, self.min_section_size) {
+                    return Ok(group.into_iter().cloned().collect());
+                }
+                candidates(target_name)
+            }
+            Authority::Section(ref target_name) => {
+                let (prefix, section) = self.closest_section(target_name);
+                if *prefix == self.our_prefix {
+                    // Exclude our name since we don't need to send to ourself
+                    let mut section = section.clone();
+                    let _ = section.remove(&self.our_name);
+                    return Ok(section);
+                }
+                candidates(target_name)
+            }
+            Authority::PrefixSection(ref prefix) => {
+                if prefix.is_compatible(&self.our_prefix) {
+                    // only route the message when we have all the targets in our routing table -
+                    // this is to prevent spamming the network by sending messages with
+                    // intentionally short prefixes
+                    if prefix.is_covered_by(self.prefixes().iter()) {
+                        let is_compatible = |(pfx, &(_, ref section))| {
+                            if prefix.is_compatible(pfx) {
+                                Some(section)
+                            } else {
+                                None
+                            }
+                        };
+                        return Ok(self
+                            .sections
+                            .iter()
+                            .filter_map(is_compatible)
+                            .flat_map(BTreeSet::iter)
+                            .chain(
+                                self.our_section
+                                    .iter()
+                                    .filter(|name| **name != self.our_name),
+                            )
+                            .cloned()
+                            .collect());
+                    } else {
+                        return Err(Error::CannotRoute);
+                    }
+                }
+                candidates(&prefix.lower_bound())
+            }
+        };
+        Ok(
+            iter::once(self.get_routeth_node(
+                &closest_section,
+                dst.name(),
+                Some(exclude),
+                route,
+            )?)
+            .collect(),
+        )
+    }
+
+    /// Returns our own section, including our own name.
+    pub fn our_section(&self) -> &BTreeSet<T> {
+        &self.our_section
+    }
+
+    /// Are we among the `count` closest nodes to `name`?
+    pub fn is_closest(&self, name: &T, count: usize) -> bool {
+        self.closest_names(name, count).is_some()
+    }
+
+    /// Returns whether we are a part of the given authority.
+    pub fn in_authority(&self, auth: &Authority<T>) -> bool {
+        match *auth {
+            // clients have no routing tables
+            Authority::Client { .. } => false,
+            Authority::ManagedNode(ref name) => self.our_name == *name,
+            Authority::ClientManager(ref name)
+            | Authority::NaeManager(ref name)
+            | Authority::NodeManager(ref name) => self.is_closest(name, self.min_section_size),
+            Authority::Section(ref name) => self.our_prefix.matches(name),
+            Authority::PrefixSection(ref prefix) => self.our_prefix.is_compatible(prefix),
+        }
+    }
+
+    /// Returns the total number of entries in the routing table, excluding our own name.
+    pub fn len(&self) -> usize {
+        self.all_sections_iter()
+            .map(|(_, (_, section))| section.len())
+            .sum::<usize>()
+            - 1
+    }
+
+    /// Compute an estimate of the size of the network from the size of our routing table.
+    ///
+    /// Return (estimate, exact), with exact = true iff we have the whole network in our
+    /// routing table.
+    pub fn network_size_estimate(&self) -> (u64, bool) {
+        let known_prefixes = self.prefixes();
+        let is_exact = Prefix::default().is_covered_by(known_prefixes.iter());
+
+        // Estimated fraction of the network that we have in our RT.
+        // Computed as the sum of 1 / 2^(prefix.bit_count) for all known section prefixes.
+        let network_fraction: f64 = known_prefixes
+            .iter()
+            .map(|p| 1.0 / (p.bit_count() as f64).exp2())
+            .sum();
+
+        // Total size estimate = known_nodes / network_fraction
+        let network_size = (self.len() + 1) as f64 / network_fraction;
+
+        (network_size.ceil() as u64, is_exact)
+    }
+
+    /// Return a minimum length prefix, favouring our prefix if it is one of the shortest.
+    pub fn min_len_prefix(&self) -> Prefix<T> {
+        *iter::once(&self.our_prefix)
+            .chain(self.sections.keys())
+            .min_by_key(|prefix| prefix.bit_count())
+            .unwrap_or(&self.our_prefix)
+    }
 }
 
 /// The outcome of a prefix change.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1280,7 +1280,11 @@ impl Chain {
 
     /// Returns our own section, including our own name.
     pub fn our_section(&self) -> BTreeSet<XorName> {
-        self.our_info().member_names()
+        if self.our_infos.is_empty() {
+            Default::default()
+        } else {
+            self.our_info().member_names()
+        }
     }
 
     /// Are we among the `count` closest nodes to `name`?
@@ -1289,18 +1293,28 @@ impl Chain {
     }
 
     /// Returns whether we are a part of the given authority.
-    pub fn in_authority(&self, auth: &Authority<XorName>, connected_peers: &[&XorName]) -> bool {
+    pub fn in_authority(
+        &self,
+        auth: &Authority<XorName>,
+        connected_peers: &[&XorName],
+        our_name: &XorName,
+    ) -> bool {
+        let our_pfx = if self.our_infos.is_empty() {
+            Default::default()
+        } else {
+            *self.our_prefix()
+        };
         match *auth {
             // clients have no routing tables
             Authority::Client { .. } => false,
-            Authority::ManagedNode(ref name) => self.our_id().name() == name,
+            Authority::ManagedNode(ref name) => our_name == name,
             Authority::ClientManager(ref name)
             | Authority::NaeManager(ref name)
             | Authority::NodeManager(ref name) => {
                 self.is_closest(name, self.min_sec_size, connected_peers)
             }
-            Authority::Section(ref name) => self.our_prefix().matches(name),
-            Authority::PrefixSection(ref prefix) => self.our_prefix().is_compatible(prefix),
+            Authority::Section(ref name) => our_pfx.matches(name),
+            Authority::PrefixSection(ref prefix) => our_pfx.is_compatible(prefix),
         }
     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -22,11 +22,12 @@ use super::{
 use crate::error::RoutingError;
 use crate::id::{FullId, PublicId};
 use crate::messages::SignedMessage;
-use crate::routing_table::Sections;
+use crate::routing_table::{Authority, Error, Sections};
 use crate::sha3::Digest256;
 use crate::{Prefix, XorName, Xorable};
 use itertools::Itertools;
 use log::LogLevel;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::iter;
@@ -76,6 +77,7 @@ pub struct Chain {
     merging: BTreeSet<Digest256>,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Chain {
     /// Returns the minimum section size.
     pub fn min_sec_size(&self) -> usize {
@@ -455,6 +457,16 @@ impl Chain {
     /// Returns our own current section's prefix.
     pub fn our_prefix(&self) -> &Prefix<XorName> {
         self.our_info().prefix()
+    }
+
+    /// Returns our own current section's prefix.
+    // FIXME: this is a ugly workaround for now.
+    pub fn our_prefix_copy(&self) -> Prefix<XorName> {
+        if self.our_infos.is_empty() {
+            Default::default()
+        } else {
+            *self.our_info().prefix()
+        }
     }
 
     /// Returns our current chain state.
@@ -991,18 +1003,22 @@ impl Chain {
         self.neighbour_infos
             .iter()
             .map(|(pfx, sec_sigs)| (*pfx, (0, sec_sigs.sec_info().member_names())))
-            .chain(iter::once((*self.our_prefix(), (0, self.our_info().member_names()))))
-            .collect::<BTreeMap<_,_>>()
+            .chain(iter::once((
+                *self.our_prefix(),
+                (0, self.our_info().member_names()),
+            )))
+            .collect::<BTreeMap<_, _>>()
     }
 
     /// Finds the `count` names closest to `name` in the whole routing table.
-    fn closest_known_names(&self, name: &T, count: usize) -> Vec<&T> {
-        self.all_sections_iter()
+    fn closest_known_names(&self, name: &XorName, count: usize) -> Vec<XorName> {
+        self.all_sections()
+            .into_iter()
             .sorted_by(|&(pfx0, _), &(pfx1, _)| pfx0.cmp_distance(&pfx1, name))
             .into_iter()
             .flat_map(|(_, (_, section))| {
                 section
-                    .iter()
+                    .into_iter()
                     .sorted_by(|name0, name1| name.cmp_distance(name0, name1))
             })
             .take(count)
@@ -1010,18 +1026,18 @@ impl Chain {
     }
 
     /// Returns whether the table contains the given `name`.
-    pub fn has(&self, name: &T) -> bool {
-        self.get_section(name)
+    fn has(&self, name: &XorName) -> bool {
+        self.get_section_legacy(name)
             .map_or(false, |section| section.contains(name))
     }
 
     /// Returns the prefix of the section in which `name` belongs, or `None` if there is no such
     /// section in the routing table.
-    pub fn find_section_prefix(&self, name: &T) -> Option<Prefix<T>> {
-        if self.our_prefix.matches(name) {
-            return Some(self.our_prefix);
+    fn find_section_prefix(&self, name: &XorName) -> Option<Prefix<XorName>> {
+        if self.our_prefix().matches(name) {
+            return Some(*self.our_prefix());
         }
-        self.sections
+        self.neighbour_infos
             .keys()
             .find(|&prefix| prefix.matches(name))
             .cloned()
@@ -1029,20 +1045,23 @@ impl Chain {
 
     /// Returns the section matching the given `name`, if present.
     /// Includes our own name in the case that our prefix matches `name`.
-    pub fn get_section(&self, name: &T) -> Option<&BTreeSet<T>> {
-        if self.our_prefix.matches(name) {
-            return Some(&self.our_section);
+    fn get_section_legacy(&self, name: &XorName) -> Option<BTreeSet<XorName>> {
+        if self.our_prefix().matches(name) {
+            return Some(self.our_info().member_names());
         }
         if let Some(prefix) = self.find_section_prefix(name) {
-            return self.sections.get(&prefix).map(|&(_, ref section)| section);
+            return self
+                .all_sections()
+                .get(&prefix)
+                .map(|(_, section)| section.clone());
         }
         None
     }
 
     /// If our section is the closest one to `name`, returns all names in our section *including
     /// ours*, otherwise returns `None`.
-    pub fn close_names(&self, name: &T) -> Option<BTreeSet<T>> {
-        if self.our_prefix.matches(name) {
+    pub fn close_names(&self, name: &XorName) -> Option<BTreeSet<XorName>> {
+        if self.our_prefix().matches(name) {
             Some(self.our_section().clone())
         } else {
             None
@@ -1051,10 +1070,10 @@ impl Chain {
 
     /// If our section is the closest one to `name`, returns all names in our section *excluding
     /// ours*, otherwise returns `None`.
-    pub fn other_close_names(&self, name: &T) -> Option<BTreeSet<T>> {
-        if self.our_prefix.matches(name) {
-            let mut section = self.our_section.clone();
-            let _ = section.remove(&self.our_name);
+    pub fn other_close_names(&self, name: &XorName) -> Option<BTreeSet<XorName>> {
+        if self.our_prefix().matches(name) {
+            let mut section = self.our_info().member_names();
+            let _ = section.remove(&self.our_id().name());
             Some(section)
         } else {
             None
@@ -1063,9 +1082,9 @@ impl Chain {
 
     /// Returns the `count` closest entries to `name` in the routing table, including our own name,
     /// sorted by ascending distance to `name`. If we are not close, returns `None`.
-    pub fn closest_names(&self, name: &T, count: usize) -> Option<Vec<&T>> {
+    pub fn closest_names(&self, name: &XorName, count: usize) -> Option<Vec<XorName>> {
         let result = self.closest_known_names(name, count);
-        if result.contains(&&self.our_name) {
+        if result.contains(&&self.our_id().name()) {
             Some(result)
         } else {
             None
@@ -1075,19 +1094,19 @@ impl Chain {
     /// Returns the `count-1` closest entries to `name` in the routing table, excluding
     /// our own name, sorted by ascending distance to `name` -  or `None`, if our name
     /// isn't among `count` names closest to `name`.
-    pub fn other_closest_names(&self, name: &T, count: usize) -> Option<Vec<&T>> {
+    fn other_closest_names(&self, name: &XorName, count: usize) -> Option<Vec<XorName>> {
         self.closest_names(name, count).map(|mut result| {
-            result.retain(|name| *name != &self.our_name);
+            result.retain(|name| name != self.our_id().name());
             result
         })
     }
 
     /// Returns the prefix of the closest non-empty section to `name`, regardless of whether `name`
     /// belongs in that section or not, and the section itself.
-    fn closest_section(&self, name: &T) -> (&Prefix<T>, &BTreeSet<T>) {
-        let mut result = (&self.our_prefix, &self.our_section);
-        for (prefix, &(_, ref section)) in &self.sections {
-            if !section.is_empty() && result.0.cmp_distance(prefix, name) == Ordering::Greater {
+    fn closest_section(&self, name: &XorName) -> (Prefix<XorName>, BTreeSet<XorName>) {
+        let mut result = (*self.our_prefix(), self.our_info().member_names());
+        for (prefix, (_, section)) in self.all_sections() {
+            if !section.is_empty() && result.0.cmp_distance(&prefix, name) == Ordering::Greater {
                 result = (prefix, section)
             }
         }
@@ -1095,11 +1114,11 @@ impl Chain {
     }
 
     /// Gets the `route`-th name from a collection of names
-    fn get_routeth_name<'a, U: IntoIterator<Item = &'a T>>(
+    fn get_routeth_name<'a, U: IntoIterator<Item = &'a XorName>>(
         names: U,
-        dst_name: &T,
+        dst_name: &XorName,
         route: usize,
-    ) -> &'a T {
+    ) -> &'a XorName {
         let sorted_names = names
             .into_iter()
             .sorted_by(|&lhs, &rhs| dst_name.cmp_distance(lhs, rhs));
@@ -1109,11 +1128,11 @@ impl Chain {
     /// Returns the `route`-th node in the given section, sorted by distance to `target`
     fn get_routeth_node(
         &self,
-        section: &BTreeSet<T>,
-        target: T,
-        exclude: Option<T>,
+        section: &BTreeSet<XorName>,
+        target: XorName,
+        exclude: Option<XorName>,
         route: usize,
-    ) -> Result<T, Error> {
+    ) -> Result<XorName, Error> {
         let names = if let Some(exclude) = exclude {
             section.iter().filter(|&x| *x != exclude).collect_vec()
         } else {
@@ -1124,7 +1143,7 @@ impl Chain {
             return Err(Error::CannotRoute);
         }
 
-        Ok(*RoutingTable::get_routeth_name(names, &target, route))
+        Ok(*Chain::get_routeth_name(names, &target, route))
     }
 
     /// Returns a collection of nodes to which a message for the given `Authority` should be sent
@@ -1155,16 +1174,15 @@ impl Chain {
     ///     - returns the `route`-th closest member of the RT to the target
     pub fn targets(
         &self,
-        dst: &Authority<T>,
-        exclude: T,
+        dst: &Authority<XorName>,
+        exclude: XorName,
         route: usize,
-    ) -> Result<BTreeSet<T>, Error> {
-        let candidates = |target_name: &T| {
-            self.closest_known_names(target_name, self.min_section_size)
+    ) -> Result<BTreeSet<XorName>, Error> {
+        let candidates = |target_name: &XorName| {
+            self.closest_known_names(target_name, self.min_sec_size)
                 .into_iter()
-                .filter(|name| **name != self.our_name)
-                .cloned()
-                .collect::<BTreeSet<T>>()
+                .filter(|name| name != self.our_id().name())
+                .collect::<BTreeSet<XorName>>()
         };
 
         let closest_section = match *dst {
@@ -1173,7 +1191,7 @@ impl Chain {
                 proxy_node_name: ref target_name,
                 ..
             } => {
-                if *target_name == self.our_name {
+                if target_name == self.our_id().name() {
                     return Ok(BTreeSet::new());
                 }
                 if self.has(target_name) {
@@ -1184,23 +1202,23 @@ impl Chain {
             Authority::ClientManager(ref target_name)
             | Authority::NaeManager(ref target_name)
             | Authority::NodeManager(ref target_name) => {
-                if let Some(group) = self.other_closest_names(target_name, self.min_section_size) {
-                    return Ok(group.into_iter().cloned().collect());
+                if let Some(group) = self.other_closest_names(target_name, self.min_sec_size) {
+                    return Ok(group.into_iter().collect());
                 }
                 candidates(target_name)
             }
             Authority::Section(ref target_name) => {
                 let (prefix, section) = self.closest_section(target_name);
-                if *prefix == self.our_prefix {
+                if &prefix == self.our_prefix() {
                     // Exclude our name since we don't need to send to ourself
                     let mut section = section.clone();
-                    let _ = section.remove(&self.our_name);
+                    let _ = section.remove(&self.our_id().name());
                     return Ok(section);
                 }
                 candidates(target_name)
             }
             Authority::PrefixSection(ref prefix) => {
-                if prefix.is_compatible(&self.our_prefix) {
+                if prefix.is_compatible(&self.our_prefix()) {
                     // only route the message when we have all the targets in our routing table -
                     // this is to prevent spamming the network by sending messages with
                     // intentionally short prefixes
@@ -1213,14 +1231,15 @@ impl Chain {
                             }
                         };
                         return Ok(self
-                            .sections
+                            .all_sections()
                             .iter()
                             .filter_map(is_compatible)
                             .flat_map(BTreeSet::iter)
                             .chain(
-                                self.our_section
+                                self.our_info()
+                                    .member_names()
                                     .iter()
-                                    .filter(|name| **name != self.our_name),
+                                    .filter(|name| *name != self.our_id().name()),
                             )
                             .cloned()
                             .collect());
@@ -1243,32 +1262,33 @@ impl Chain {
     }
 
     /// Returns our own section, including our own name.
-    pub fn our_section(&self) -> &BTreeSet<T> {
-        &self.our_section
+    pub fn our_section(&self) -> BTreeSet<XorName> {
+        self.our_info().member_names()
     }
 
     /// Are we among the `count` closest nodes to `name`?
-    pub fn is_closest(&self, name: &T, count: usize) -> bool {
+    fn is_closest(&self, name: &XorName, count: usize) -> bool {
         self.closest_names(name, count).is_some()
     }
 
     /// Returns whether we are a part of the given authority.
-    pub fn in_authority(&self, auth: &Authority<T>) -> bool {
+    pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
         match *auth {
             // clients have no routing tables
             Authority::Client { .. } => false,
-            Authority::ManagedNode(ref name) => self.our_name == *name,
+            Authority::ManagedNode(ref name) => self.our_id().name() == name,
             Authority::ClientManager(ref name)
             | Authority::NaeManager(ref name)
-            | Authority::NodeManager(ref name) => self.is_closest(name, self.min_section_size),
-            Authority::Section(ref name) => self.our_prefix.matches(name),
-            Authority::PrefixSection(ref prefix) => self.our_prefix.is_compatible(prefix),
+            | Authority::NodeManager(ref name) => self.is_closest(name, self.min_sec_size),
+            Authority::Section(ref name) => self.our_prefix().matches(name),
+            Authority::PrefixSection(ref prefix) => self.our_prefix().is_compatible(prefix),
         }
     }
 
     /// Returns the total number of entries in the routing table, excluding our own name.
     pub fn len(&self) -> usize {
-        self.all_sections_iter()
+        self.all_sections()
+            .into_iter()
             .map(|(_, (_, section))| section.len())
             .sum::<usize>()
             - 1
@@ -1296,11 +1316,15 @@ impl Chain {
     }
 
     /// Return a minimum length prefix, favouring our prefix if it is one of the shortest.
-    pub fn min_len_prefix(&self) -> Prefix<T> {
-        *iter::once(&self.our_prefix)
-            .chain(self.sections.keys())
-            .min_by_key(|prefix| prefix.bit_count())
-            .unwrap_or(&self.our_prefix)
+    pub fn min_len_prefix(&self) -> Prefix<XorName> {
+        if self.our_infos.is_empty() {
+            Default::default()
+        } else {
+            *iter::once(self.our_prefix())
+                .chain(self.all_sections().keys())
+                .min_by_key(|prefix| prefix.bit_count())
+                .unwrap_or(&self.our_prefix())
+        }
     }
 }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -22,6 +22,7 @@ use super::{
 use crate::error::RoutingError;
 use crate::id::{FullId, PublicId};
 use crate::messages::SignedMessage;
+use crate::routing_table::Sections;
 use crate::sha3::Digest256;
 use crate::{Prefix, XorName, Xorable};
 use itertools::Itertools;
@@ -980,6 +981,17 @@ impl Chain {
             .filter(move |(_, proofs)| proofs.contains_id(&self.our_id))
             .map(|(event, _)| event)
     }
+
+    /// Convert from collection of SectionInfo to Sections type. All neighbouring sections and our
+    /// own.
+    fn all_sections(&self) -> Sections<XorName> {
+        self.neighbour_infos
+            .iter()
+            .map(|(pfx, sec_sigs)| (*pfx, (0, sec_sigs.sec_info().member_names())))
+            .chain(iter::once((*self.our_prefix(), (0, self.our_info().member_names()))))
+            .collect::<BTreeMap<_,_>>()
+    }
+
 }
 
 /// The outcome of a prefix change.

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -96,6 +96,10 @@ impl SectionInfo {
         &self.members
     }
 
+    pub fn member_names(&self) -> BTreeSet<XorName> {
+        self.members.iter().map(PublicId::name).cloned().collect()
+    }
+
     pub fn version(&self) -> &u64 {
         &self.version
     }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -2418,10 +2418,15 @@ impl Node {
             return Err(RoutingError::InvalidDestination);
         }
 
-        let close_section = match self.chain().close_names(&dst_name) {
-            Some(close_section) => close_section.into_iter().collect(),
-            None => return Err(RoutingError::InvalidDestination),
+        let close_section = if self.is_first_node && !self.chain.is_member() {
+            iter::once(self.name()).cloned().collect_vec()
+        } else {
+            match self.chain().close_names(&dst_name) {
+                Some(close_section) => close_section.into_iter().collect(),
+                None => return Err(RoutingError::InvalidDestination),
+            }
         };
+
         let relocation_dst = self
             .next_relocation_dst
             .unwrap_or_else(|| utils::calculate_relocation_dst(close_section, &dst_name));

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -3076,10 +3076,14 @@ impl Node {
         };
 
         if (self.is_first_node || self.chain.is_member()) && !force_via_proxy {
+            // TODO: even if having chain reply based on connected_state,
+            // we remove self in targets info and can do same by not
+            // chaining us to conn_peer list here?
             let conn_peers = self
                 .peer_mgr
                 .connected_peers()
                 .map(Peer::name)
+                .chain(iter::once(self.name()))
                 .collect_vec();
             let targets: BTreeSet<_> = self
                 .chain()
@@ -3413,6 +3417,7 @@ impl Base for Node {
                 .peer_mgr
                 .connected_peers()
                 .map(Peer::name)
+                .chain(iter::once(self.name()))
                 .collect_vec();
             (self.is_first_node || self.chain.is_member())
                 && self.chain().in_authority(auth, &conn_peers, self.name())

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1497,8 +1497,7 @@ impl Node {
                 .iter()
                 .cloned()
                 .collect();
-            let first_info =
-                SectionInfo::new(our_members, *self.routing_table().our_prefix(), None)?;
+            let first_info = SectionInfo::new(our_members, Default::default(), None)?;
             self.gen_pfx_info = Some(GenesisPfxInfo {
                 our_info: first_info,
                 latest_info: Default::default(),
@@ -3410,7 +3409,7 @@ impl Base for Node {
                 .map(Peer::name)
                 .collect_vec();
             (self.is_first_node || self.chain.is_member())
-                && self.chain().in_authority(auth, &conn_peers)
+                && self.chain().in_authority(auth, &conn_peers, self.name())
         }
     }
 

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -301,7 +301,7 @@ impl Node {
             let status_str = format!(
                 "{} - Routing Table size: {:3}",
                 self,
-                self.chain.valid_peers().len()
+                self.chain.valid_peers(true).len()
             );
             let network_estimate = match self.chain().network_size_estimate() {
                 (n, true) => format!("Exact network size: {}", n),
@@ -952,7 +952,7 @@ impl Node {
 
         let peers_to_connect: BTreeSet<PublicId> = self
             .chain
-            .valid_peers()
+            .valid_peers(true)
             .iter()
             .filter_map(|pub_id| {
                 if self.peer_mgr.get_peer(pub_id).is_none() && *pub_id != self.full_id.public_id() {
@@ -3018,24 +3018,30 @@ impl Node {
     /// may be us or another node. If our signature is not required, this returns `None`.
     fn get_signature_target(&self, src: &Authority<XorName>, route: u8) -> Option<XorName> {
         use crate::Authority::*;
+        let (our_section, valid_peers) = if self.chain().is_member() {
+            // FIXME: we're passing false here to valid peers to not include
+            // recently accepted peers which would affect quorum calculation.
+            // This even when going via RT would have only allowed route-0
+            // to succeed as by ack-failure, the new node would have been
+            // accepted to the RT. Need a better network startup separation.
+            (self.chain().our_section(), self.chain().valid_peers(false))
+        } else {
+            let our_section: BTreeSet<XorName> = iter::once(self.name()).cloned().collect();
+            let valid_peers: BTreeSet<&PublicId> = iter::once(self.id()).collect();
+            (our_section, valid_peers)
+        };
         let list: Vec<XorName> = match *src {
             ClientManager(_) | NaeManager(_) | NodeManager(_) => {
-                let mut v = self
-                    .chain()
-                    .our_section()
+                let mut v = our_section
                     .into_iter()
                     .sorted_by(|lhs, rhs| src.name().cmp_distance(lhs, rhs));
                 v.truncate(self.min_section_size());
                 v
             }
-            Section(_) => self
-                .chain()
-                .our_section()
+            Section(_) => our_section
                 .into_iter()
                 .sorted_by(|lhs, rhs| src.name().cmp_distance(lhs, rhs)),
-            PrefixSection(_) => self
-                .chain()
-                .valid_peers()
+            PrefixSection(_) => valid_peers
                 .iter()
                 .map(|id| id.name())
                 .sorted_by(|lhs, rhs| src.name().cmp_distance(lhs, rhs))

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -674,7 +674,7 @@ pub fn verify_invariant_for_all_nodes(nodes: &mut [TestNode]) {
         // Confirm valid peers from chain are connected according to PeerMgr
         for pub_id in node
             .chain()
-            .valid_peers()
+            .valid_peers(true)
             .iter()
             .filter(|id| **id != node.chain().our_id())
         {


### PR DESCRIPTION
As a first step towards deduplicating the routing table and chain state, states/node should depend on the chain state rather than routing table state. This PR first copies over the relevant methods and then modifies them to work with the "ideal" chain state.